### PR TITLE
Fixed: Remove extra coma between movies in movie list

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -66,5 +66,5 @@ function displayMovies(movies, buttonText, icon = '', message = '') {
     `;
   });
 
-  movieList.innerHTML = movieEls;
+  movieList.innerHTML = movieEls.join('\n');
 }


### PR DESCRIPTION
Removed extra coma that was shown between movies in the movie list.

See #31